### PR TITLE
Copy over the README.md with gulp build and deploy.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -82,6 +82,9 @@ gulp.task('copy', function () {
     dot: true
   }).pipe(gulp.dest('dist'));
 
+  var readme = gulp.src(['README.md'])
+    .pipe(gulp.dest('dist'));
+
   var bower = gulp.src([
     'bower_components/**/*'
   ]).pipe(gulp.dest('dist/bower_components'));
@@ -99,7 +102,7 @@ gulp.task('copy', function () {
     .pipe($.rename('elements.vulcanized.html'))
     .pipe(gulp.dest('dist/elements'));
 
-  return merge(app, bower, elements, vulcanized, swBootstrap, swToolbox)
+  return merge(app, readme, bower, elements, vulcanized, swBootstrap, swToolbox)
     .pipe($.size({title: 'copy'}));
 });
 


### PR DESCRIPTION
Added the instruction to the `gulpfile.js` as part of the `copy` task to also copy the `README.md` file to `dist/`.  Now, our repository will have a `README.md` file on master.
