### PR TITLE
Always redirect to #/ when page not found.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -82,6 +82,8 @@
         path="/collaborate"
         template import="/pages/collaborate.html">
       </app-route> -->
+
+      <app-route path="*" redirect="/"></app-route>
     </app-router>
   </template>
 

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -20,6 +20,14 @@
     }, 100);
   };
 
+  var onHashChange = function() {
+    if (!window.location.hash || window.location.hash[0] !== "/") {
+      window.location.hash = "/";
+    }
+  };
+  window.addEventListener("hashchange", onHashChange);
+  onHashChange();
+
   app.addEventListener("dom-change", function() {
     // The contents of the app template have loaded
   });


### PR DESCRIPTION
Ensures the hash will be #/ when not #/join or #/learn.  This eliminates some weird behavior that occurs when the hash is set to a page that doesn't exist.
