### PR TITLE
Fix bug on Safari and Firefox.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -33,14 +33,13 @@
   <meta name="msapplication-TileImage" content="images/touch/ms-touch-icon-144x144-precomposed.png">
   <meta name="viewport" content="initial-scale=1" />
 
-  <!-- will be replaced with elements/elements.vulcanized.html -->
-  <link rel="import" href="elements/elements.html">
-  <!-- endreplace-->
-
   <!-- build:js bower_components/webcomponentsjs/webcomponents-lite.min.js -->
   <script src="bower_components/webcomponentsjs/webcomponents-lite.js"></script>
   <!-- endbuild -->
 
+  <!-- will be replaced with elements/elements.vulcanized.html -->
+  <link rel="import" href="elements/elements.html">
+  <!-- endreplace-->
 </head>
 
 <body unresolved>


### PR DESCRIPTION
YAAAAAY!!!!!

Turns out, it was really stupid.  We just had the import to the webcomponents polyfill after the import to elements.html, not before.  I have no idea how our site ever worked on Safari or Firefox.
