### PR TITLE
Clean uris

### DIFF
--- a/app/elements/member-card/member-card.html
+++ b/app/elements/member-card/member-card.html
@@ -157,7 +157,7 @@
       },
 
       _getWebpageURI: function(name, _pageConfig) {
-        return _pageConfig.uri || '/roster/' + name + '/index.html';
+        return _pageConfig.uri || '/roster/' + name;
       },
 
       _pageConfigFileURI: function(name) {


### PR DESCRIPTION
Now, member pages have cleaner uri's, without the `index.html` in the path.  For example, my page is at `/roster/Zander_Otavka` not `/roster/Zander_Otavka/index.html`.
