### PR TITLE
Fix topbar.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,10 +8,11 @@
     "paper-elements": "PolymerElements/paper-elements#~1.0.5",
     "paper-toolbar": "PolymerElements/paper-toolbar#~1.0.4",
     "parallax-container": "~0.0.3",
-    "polymer": "Polymer/polymer#^1.0.3",
-    "webcomponentsjs": "#^0.7.14"
+    "polymer": "Polymer/polymer#1.0.3",
+    "webcomponentsjs": "#0.7.14"
   },
   "resolutions": {
-    "polymer": "^1.0.3"
+    "polymer": "^1.1.0",
+    "webcomponentsjs": "0.7.14"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -6,12 +6,12 @@
     "iron-elements": "PolymerElements/iron-elements#~1.0.3",
     "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#~1.0.6",
     "paper-elements": "PolymerElements/paper-elements#~1.0.5",
+    "paper-toolbar": "PolymerElements/paper-toolbar#~1.0.4",
     "parallax-container": "~0.0.3",
-    "polymer": "Polymer/polymer#1.0.3",
-    "webcomponentsjs": "#0.7.14"
+    "polymer": "Polymer/polymer#^1.0.3",
+    "webcomponentsjs": "#^0.7.14"
   },
   "resolutions": {
-    "polymer": "^1.1.0",
-    "webcomponentsjs": "0.7.14"
+    "polymer": "^1.0.3"
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -254,6 +254,8 @@ var serveTask = function(browser) {
   gulp.watch(['app/{scripts,elements}/**/{*.js,*.html}'], ['jshint']);
   gulp.watch(['app/images/**/*'], reload);
   gulp.watch(['app/roster/**'], ['generate-roster', reload]);
+
+  gulp.watch(['bower_components/**/*'], reload);
 };
 
 var serveSubTasks = ['styles', 'elements', 'images', 'generate-roster'];


### PR DESCRIPTION
Revert paper-toolbar to v1.0.4 because the new one seems to be buggy, and I can't fix it.

Also, cleanup bower.json, and auto-reload browsers when bower_components changes.
